### PR TITLE
Add decorative window graphic at top of site

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
 <title>Page Not Found — Clean & Mean Services</title>
 <link rel="stylesheet" href="/assets/styles.css">
 </head><body>
+<div class="top-graphic"><img src="/assets/images/window.svg" alt="Stylized window graphic"></div>
 <section class="section"><div class="container center">
   <h1>404</h1>
   <p class="lead">We couldn’t find that page.</p>

--- a/assets/images/window.svg
+++ b/assets/images/window.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="70" height="70" stroke="currentColor" stroke-width="5" fill="none" />
+  <line x1="5" y1="40" x2="75" y2="40" stroke="currentColor" stroke-width="5" />
+  <line x1="40" y1="5" x2="40" y2="75" stroke="currentColor" stroke-width="5" />
+</svg>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -15,6 +15,8 @@
 html,body{margin:0;padding:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:var(--text);background:linear-gradient(180deg,var(--surface),#0a0f1e 800px)}
 img{max-width:100%;display:block;border-radius:14px}
 .container{max-width:1100px;margin:0 auto;padding:0 20px}
+.top-graphic{color:var(--brand);text-align:center;padding:20px 0}
+.top-graphic img{width:80px;margin:0 auto}
 
 .site-header{position:sticky;top:0;background:rgba(10,15,30,.6);backdrop-filter: blur(10px);border-bottom:1px solid rgba(255,255,255,.06);z-index:20}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:20px;padding:14px 0}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,9 @@
   <script defer src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 </head>
 <body>
+  <div class="top-graphic">
+    <img src="/assets/images/window.svg" alt="Stylized window graphic" />
+  </div>
   <header class="site-header">
     <div class="container nav">
       <a class="brand" href="/"><img class="logo" src="/assets/images/logo.svg" alt="Clean &amp; Mean logo"/>Clean &amp; Mean Services</a>

--- a/privacy.html
+++ b/privacy.html
@@ -3,6 +3,7 @@
 <title>Privacy Policy — Clean & Mean Services</title>
 <link rel="stylesheet" href="/assets/styles.css">
 </head><body>
+<div class="top-graphic"><img src="/assets/images/window.svg" alt="Stylized window graphic"></div>
 <header class="site-header"><div class="container nav">
   <a class="brand" href="/"><img class="logo" src="/assets/images/logo.svg" alt="">Clean &amp; Mean Services</a>
 </div></header>

--- a/terms.html
+++ b/terms.html
@@ -3,6 +3,7 @@
 <title>Terms of Service — Clean & Mean Services</title>
 <link rel="stylesheet" href="/assets/styles.css">
 </head><body>
+<div class="top-graphic"><img src="/assets/images/window.svg" alt="Stylized window graphic"></div>
 <header class="site-header"><div class="container nav">
   <a class="brand" href="/"><img class="logo" src="/assets/images/logo.svg" alt="">Clean &amp; Mean Services</a>
 </div></header>


### PR DESCRIPTION
## Summary
- Add stylized window SVG and display it above the header on all pages
- Style graphic with site brand color and consistent sizing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5edd1ac6c8321b53dc9695aff0f0b